### PR TITLE
과제 및 코딩테스트 코드 제출

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
         "@nestjs/common": "^10.0.0",
         "@nestjs/core": "^10.0.0",
         "@nestjs/platform-express": "^10.0.0",
+        "@nestjs/schedule": "^4.0.0",
+        "class-transformer": "^0.5.1",
+        "class-validator": "^0.14.0",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1"
       },
@@ -19,6 +22,7 @@
         "@nestjs/cli": "^10.0.0",
         "@nestjs/schematics": "^10.0.0",
         "@nestjs/testing": "^10.0.0",
+        "@types/cron": "^2.4.0",
         "@types/express": "^4.17.17",
         "@types/jest": "^29.5.2",
         "@types/node": "^20.3.1",
@@ -1678,6 +1682,20 @@
         "@nestjs/core": "^10.0.0"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-4.0.0.tgz",
+      "integrity": "sha512-zz4h54m/F/1qyQKvMJCRphmuwGqJltDAkFxUXCVqJBXEs5kbPt93Pza3heCQOcMH22MZNhGlc9DmDMLXVHmgVQ==",
+      "dependencies": {
+        "cron": "3.1.3",
+        "uuid": "9.0.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "reflect-metadata": "^0.1.12"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "10.0.3",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-10.0.3.tgz",
@@ -1917,6 +1935,16 @@
       "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
       "dev": true
     },
+    "node_modules/@types/cron": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@types/cron/-/cron-2.4.0.tgz",
+      "integrity": "sha512-5bBaAkqvSFBX8JMi/xCofNzG5E594TNsApMz68dLd/sQYz/HGQqgcxGHTRjOvD4G3Y+YF1Oo3S7QdCvKt1KAJQ==",
+      "deprecated": "This is a stub types definition. cron provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "dependencies": {
+        "cron": "*"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "8.44.8",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.8.tgz",
@@ -2022,6 +2050,11 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
+    "node_modules/@types/luxon": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.3.7.tgz",
+      "integrity": "sha512-gKc9P2d4g5uYwmy4s/MO/yOVPmvHyvzka1YH6i5dM03UrFofHSmgc0D0ymbDRStFWHusk6cwwF6nhLm/ckBbbQ=="
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -2100,6 +2133,11 @@
       "dependencies": {
         "@types/superagent": "*"
       }
+    },
+    "node_modules/@types/validator": {
+      "version": "13.11.7",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.7.tgz",
+      "integrity": "sha512-q0JomTsJ2I5Mv7dhHhQLGjMvX0JJm5dyZ1DXQySIUzU1UlwzB8bt+R6+LODUbz0UDIOvEzGc28tk27gBJw2N8Q=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
@@ -3183,6 +3221,21 @@
       "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
       "dev": true
     },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
+    },
+    "node_modules/class-validator": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.0.tgz",
+      "integrity": "sha512-ct3ltplN8I9fOwUd8GrP8UQixwff129BkEtuWDKL5W45cQuLd19xqmTLu5ge78YDm/fdje6FMt0hGOhl0lii3A==",
+      "dependencies": {
+        "@types/validator": "^13.7.10",
+        "libphonenumber-js": "^1.10.14",
+        "validator": "^13.7.0"
+      }
+    },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -3487,6 +3540,15 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/cron": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-3.1.3.tgz",
+      "integrity": "sha512-KVxeKTKYj2eNzN4ElnT6nRSbjbfhyxR92O/Jdp6SH3pc05CDJws59jBrZWEMQlxevCiE6QUTrXy+Im3vC3oD3A==",
+      "dependencies": {
+        "@types/luxon": "~3.3.0",
+        "luxon": "~3.4.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -6135,6 +6197,11 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libphonenumber-js": {
+      "version": "1.10.52",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.52.tgz",
+      "integrity": "sha512-6vCuCHgem+OW1/VCAKgkasfegItCea8zIT7s9/CG/QxdCMIM7GfzbEBG5d7lGO3rzipjt5woOQL3DiHa8Fy78Q=="
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -6206,6 +6273,14 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
+      "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/macos-release": {
@@ -8478,6 +8553,18 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -8496,6 +8583,14 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
+      "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/schedule": "^4.0.0",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1"
   },
@@ -30,6 +33,7 @@
     "@nestjs/cli": "^10.0.0",
     "@nestjs/schematics": "^10.0.0",
     "@nestjs/testing": "^10.0.0",
+    "@types/cron": "^2.4.0",
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.2",
     "@types/node": "^20.3.1",

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,5 +1,7 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Req, ValidationPipe } from '@nestjs/common';
 import { AppService } from './app.service';
+import { RequestHeaderDTO } from './dto/request-header.dto';
+import { RequestHeaders } from './request-headers.decorator';
 
 @Controller()
 export class AppController {
@@ -7,8 +9,12 @@ export class AppController {
 
   //프록시 처리
   @Get()
-  proxy() {
-    return this.appService.proxy();
+  async proxy(
+    @Req() request: Request,
+    @RequestHeaders(new ValidationPipe({ validateCustomDecorators: true }))
+    headers: RequestHeaderDTO,
+  ) {
+    return await this.appService.proxy(request, headers.id);
   }
 
   @Get('challenge1')

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { SchedulerModule } from './scheduler/scheduler.module';
+import { ScheduleModule } from '@nestjs/schedule';
 
 @Module({
-  imports: [],
+  imports: [SchedulerModule, ScheduleModule.forRoot()],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -1,6 +1,18 @@
 import { Injectable } from '@nestjs/common';
 import { SchedulerService } from './scheduler/scheduler.service';
 
+interface Category {
+  id: number;
+  name: string;
+}
+
+interface Product {
+  id: number;
+  name: string;
+  keyword?: string;
+  category?: Category;
+}
+
 @Injectable()
 export class AppService {
   constructor(private schedulerService: SchedulerService) {}
@@ -21,7 +33,7 @@ export class AppService {
    */
   challenge1(): number {
     //함수 실행 시간 반환
-    const categoryList = [
+    const categoryList: Category[] = [
       { id: 1, name: '가구' },
       { id: 2, name: '공구' },
       { id: 3, name: '의류' },
@@ -30,13 +42,22 @@ export class AppService {
       categoryList.push({ id: index + 4, name: `카테고리${index + 4}` });
     });
 
+    // 상수 시간 내에 category name을 검색하기 위해 해시맵으로 관리
+    const categoryMap: { [key: string]: Category } = {};
+    for (const category of categoryList) {
+      categoryMap[category.name] = category;
+    }
+
     const start = Date.now();
 
-    const product = {
+    const product: Product = {
       id: 1,
       name: '의자',
       keyword: '가구',
     };
+
+    product.category = categoryMap[product.keyword as string];
+    delete product.keyword;
 
     const end = Date.now();
     return end - start;

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -1,8 +1,14 @@
 import { Injectable } from '@nestjs/common';
+import { SchedulerService } from './scheduler/scheduler.service';
 
 @Injectable()
 export class AppService {
-  proxy() {
+  constructor(private schedulerService: SchedulerService) {}
+
+  async proxy(request: Request, userId: string) {
+    // 큐에 요청 추가
+    this.schedulerService.addRequest(request, userId);
+
     //API 호출
     return true;
   }

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -78,6 +78,12 @@ export class AppService {
       translateWordList.push({ src: index.toString(), dest: `A` });
     });
 
+    // 상수 시간 내에 src를 검색하기 위해 해시맵으로 관리
+    const translateWordMap: { [key: string]: string } = {};
+    for (const word of translateWordList) {
+      translateWordMap[word.src] = word.dest;
+    }
+
     const optionList = [
       { id: 1, name: '블랙 XL' },
       { id: 2, name: '블랙 L' },
@@ -91,6 +97,16 @@ export class AppService {
     });
 
     const start = Date.now();
+
+    // 원소 수가 월등히 많은 translateWordList에 대한 반복문을 피하기 위해 정규식 생성
+    const regex = new RegExp(Object.keys(translateWordMap).join('|'), 'g');
+
+    optionList.map((option) => {
+      option.name = option.name.replace(
+        regex,
+        (matched) => translateWordMap[matched],
+      );
+    });
 
     const end = Date.now();
     return end - start;

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -43,9 +43,9 @@ export class AppService {
     });
 
     // 상수 시간 내에 category name을 검색하기 위해 해시맵으로 관리
-    const categoryMap: { [key: string]: Category } = {};
+    const categoryMap = new Map<string, Category>();
     for (const category of categoryList) {
-      categoryMap[category.name] = category;
+      categoryMap.set(category.name, category);
     }
 
     const start = Date.now();
@@ -56,7 +56,7 @@ export class AppService {
       keyword: '가구',
     };
 
-    product.category = categoryMap[product.keyword as string];
+    product.category = categoryMap.get(product.keyword as string);
     delete product.keyword;
 
     const end = Date.now();
@@ -79,9 +79,9 @@ export class AppService {
     });
 
     // 상수 시간 내에 src를 검색하기 위해 해시맵으로 관리
-    const translateWordMap: { [key: string]: string } = {};
+    const translateWordMap = new Map<string, string>();
     for (const word of translateWordList) {
-      translateWordMap[word.src] = word.dest;
+      translateWordMap.set(word.src, word.dest);
     }
 
     const optionList = [
@@ -99,12 +99,13 @@ export class AppService {
     const start = Date.now();
 
     // 원소 수가 월등히 많은 translateWordList에 대한 반복문을 피하기 위해 정규식 생성
-    const regex = new RegExp(Object.keys(translateWordMap).join('|'), 'g');
+    const regexPattern = Array.from(translateWordMap.keys()).join('|');
+    const regex = new RegExp(regexPattern, 'g');
 
     optionList.map((option) => {
       option.name = option.name.replace(
         regex,
-        (matched) => translateWordMap[matched],
+        (matched) => translateWordMap.get(matched) as string,
       );
     });
 

--- a/src/dto/request-header.dto.ts
+++ b/src/dto/request-header.dto.ts
@@ -1,0 +1,10 @@
+import { IsDefined, IsNotEmpty, Matches } from 'class-validator';
+
+const USER_ID_REGEX = /[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{4}$/;
+
+export class RequestHeaderDTO {
+  @IsNotEmpty()
+  @IsDefined()
+  @Matches(USER_ID_REGEX)
+  id!: string;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,10 @@
+import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(new ValidationPipe());
   await app.listen(3000);
 }
 bootstrap();

--- a/src/request-headers.decorator.ts
+++ b/src/request-headers.decorator.ts
@@ -1,0 +1,19 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const RequestHeaders = createParamDecorator(
+  async (property: string | number | symbol, ctx: ExecutionContext) => {
+    const headers = ctx.switchToHttp().getRequest().headers;
+
+    // 사용 예시: @RequestHeaders('content-type')
+    if (
+      typeof property === 'string' ||
+      typeof property === 'number' ||
+      typeof property === 'symbol'
+    ) {
+      return headers[property];
+    }
+
+    // 사용 예시: @RequestHeaders()
+    return headers;
+  },
+);

--- a/src/scheduler/scheduler.module.ts
+++ b/src/scheduler/scheduler.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { SchedulerService } from './scheduler.service';
+
+@Module({
+  imports: [],
+  providers: [SchedulerService],
+  exports: [SchedulerService],
+})
+export class SchedulerModule {}

--- a/src/scheduler/scheduler.service.ts
+++ b/src/scheduler/scheduler.service.ts
@@ -1,0 +1,38 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+
+const MAX_REQUEST_COUNT = 10;
+
+@Injectable()
+export class SchedulerService {
+  private readonly logger = new Logger(SchedulerService.name);
+  private userRequestQueue: { [key: string]: Request[] } = {}; // 각 유저 아이디별 요청 큐를 저장할 객체
+
+  constructor() {}
+
+  @Cron('* * * * * *')
+  async handleCron() {
+    this.logger.debug('Called every second');
+
+    for (const key of Object.keys(this.userRequestQueue)) {
+      if (this.userRequestQueue[key].length > 0) {
+        const requests = this.userRequestQueue[key].splice(
+          0,
+          MAX_REQUEST_COUNT,
+        );
+
+        for (const request of requests) {
+          // A 서버에 요청 전달
+          console.log('A 서버에 요청 전달', request);
+        }
+      }
+    }
+  }
+
+  addRequest(request: Request, userId: string) {
+    if (!this.userRequestQueue[userId]) {
+      this.userRequestQueue[userId] = []; // 해당 유저 아이디의 큐가 없으면 초기화
+    }
+    this.userRequestQueue[userId].push(request);
+  }
+}


### PR DESCRIPTION
변경 사항
- [과제] Reqeust 가공 (중계서버)
    클라이언트로부터 들어오는 요청을 중계 서버를 통해 A 서버에 전달합니다. 스케줄러가 매초 유저 아이디 별로 최대 10개 요청을 작업 큐에서 꺼낸 후 A 서버에 전달하도록 구현했습니다.

- [코딩 테스트 - 1] 상품 카테고리 매칭
    상품의 키워드를 기반으로 카테고리 목록과 매칭하여 상품에 카테고리 정보를 연결합니다. 카테고리 목록을 해시 맵으로 관리하여 검색 시 상수 시간 내에 검색할 수 있도록 구현했습니다.

- [코딩 테스트 - 2] 단어 치환
    옵션 이름 내의 특정 단어들을 단어 치환 목록을 사용하여 변경합니다.  단어 치환 목록을 해시 맵으로 관리하고 정규 표현식을 사용하여 효율적으로 치환하도록 구현했습니다.